### PR TITLE
54

### DIFF
--- a/examples/grass_colors.rs
+++ b/examples/grass_colors.rs
@@ -13,7 +13,7 @@ fn main() {
             // The color of the upper part of the grass blades
             main_color: Color::WHITE,
             // The color of the lower part
-            bottom_color: Color::ALICE_BLUE,
+            bottom_color: Color::BLACK,
             ..default()
         })
         .add_startup_system(setup_grass)

--- a/examples/many_chunks.rs
+++ b/examples/many_chunks.rs
@@ -18,10 +18,10 @@ fn main() {
         .run();
 }
 fn setup_grass_chunks(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let density_map = asset_server.load("grass_density_map.png");
+    let density_map_handle = asset_server.load("grass_density_map.png");
 
     let density_map = DensityMap {
-        density_map,
+        density_map: density_map_handle.clone(),
         density: 2.,
     };
     let height_map = asset_server.load("grass_height_map.png");
@@ -41,6 +41,7 @@ fn setup_grass_chunks(mut commands: Commands, asset_server: Res<AssetServer>) {
             density_map: density_map.clone(),
             // or seperate height maps if we wanted to
             height_map: height_map.clone(),
+            height: WarblerHeight::Texture(density_map_handle.clone()),
             // the aabb defined the dimensions of the box the chunk lives in
             aabb: Aabb::from_min_max(Vec3::ZERO, Vec3::new(chunk_width, 2., chunk_height)),
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -3,8 +3,8 @@ use bevy::{
     ecs::{bundle::Bundle, component::Component, query::QueryItem},
     math::Vec3,
     render::{
-        mesh::Mesh, prelude::SpatialBundle, primitives::Aabb, texture::Image,
-        texture::DEFAULT_IMAGE_HANDLE, extract_component::ExtractComponent,
+        extract_component::ExtractComponent, mesh::Mesh, prelude::SpatialBundle, primitives::Aabb,
+        texture::Image, texture::DEFAULT_IMAGE_HANDLE,
     },
 };
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,10 +1,10 @@
 use bevy::{
     asset::Handle,
-    ecs::{bundle::Bundle, component::Component},
+    ecs::{bundle::Bundle, component::Component, query::QueryItem},
     math::Vec3,
     render::{
         mesh::Mesh, prelude::SpatialBundle, primitives::Aabb, texture::Image,
-        texture::DEFAULT_IMAGE_HANDLE,
+        texture::DEFAULT_IMAGE_HANDLE, extract_component::ExtractComponent,
     },
 };
 
@@ -61,6 +61,20 @@ pub enum WarblerHeight {
     ///
     /// The [`Image`] will be scaled over the plane defined by the [`Aabb`]
     Texture(Handle<Image>),
+}
+impl ExtractComponent for WarblerHeight {
+    type Query = &'static Self;
+
+    type Filter = ();
+
+    type Out = Self;
+
+    fn extract_component(item: QueryItem<'_, Self::Query>) -> Option<Self::Out> {
+        match item {
+            WarblerHeight::Uniform(_) => Some(item.clone()),
+            WarblerHeight::Texture(handle) => Some(WarblerHeight::Texture(handle.clone_weak())),
+        }
+    }
 }
 
 /// Used to define the positions of all the grass blades explicitly

--- a/src/dithering.rs
+++ b/src/dithering.rs
@@ -18,7 +18,7 @@ use bevy::{
 };
 use serde::Deserialize;
 
-use crate::{density_map::DensityMap};
+use crate::density_map::DensityMap;
 
 // see https://surma.dev/things/ditherpunk/ for a good resource regarding ordered dithering
 const BAYER_DITHER: [[u8; 8]; 8] = [

--- a/src/height_map.rs
+++ b/src/height_map.rs
@@ -1,5 +1,10 @@
 //! Contains the implementation of the [`HeightMap`] component
-use bevy::{asset::Handle, ecs::component::Component, reflect::Reflect, render::texture::Image};
+use bevy::{
+    asset::Handle,
+    ecs::{component::Component, query::QueryItem},
+    reflect::Reflect,
+    render::{extract_component::ExtractComponent, texture::Image},
+};
 
 /// The height map defining the y position of the grass blades.
 ///
@@ -19,5 +24,18 @@ pub struct HeightMap {
 impl From<Handle<Image>> for HeightMap {
     fn from(value: Handle<Image>) -> Self {
         HeightMap { height_map: value }
+    }
+}
+impl ExtractComponent for HeightMap {
+    type Query = &'static Self;
+
+    type Filter = ();
+
+    type Out = Self;
+
+    fn extract_component(item: QueryItem<'_, Self::Query>) -> Option<Self::Out> {
+        Some(HeightMap {
+            height_map: item.height_map.clone_weak(),
+        })
     }
 }

--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -13,8 +13,17 @@ pub(crate) struct GrassCache {
 
 #[derive(Debug, Default)]
 pub(crate) struct CachedGrassChunk {
-    pub uniform_bindgroup: Option<BindGroup>,
     pub explicit_xz_buffer: Option<Buffer>,
     pub explicit_count: u32,
     pub dither_handle: Option<Handle<DitheredBuffer>>,
+}
+#[derive(Resource, Default)]
+pub(crate) struct UniformBuffer(pub Option<BindGroup>);
+impl UniformBuffer {
+    pub fn set(&mut self, val: BindGroup) {
+        self.0 = Some(val);
+    }
+    pub fn ref_unwrap(&self) -> &BindGroup {
+        self.0.as_ref().unwrap()
+    }
 }

--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -5,12 +5,12 @@ use bevy::{
 };
 
 #[derive(Resource, DerefMut, Deref, Debug, Default)]
-pub(crate) struct GrassCache {
-    pub data: HashMap<Entity, CachedGrassChunk>,
+pub(crate) struct ExplicitGrassCache {
+    pub data: HashMap<Entity, CachedExplicitGrassChunk>,
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct CachedGrassChunk {
+pub(crate) struct CachedExplicitGrassChunk {
     pub explicit_xz_buffer: Option<Buffer>,
     pub explicit_count: u32,
 }

--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -4,8 +4,6 @@ use bevy::{
     utils::HashMap,
 };
 
-use crate::dithering::DitheredBuffer;
-
 #[derive(Resource, DerefMut, Deref, Debug, Default)]
 pub(crate) struct GrassCache {
     pub data: HashMap<Entity, CachedGrassChunk>,
@@ -15,7 +13,6 @@ pub(crate) struct GrassCache {
 pub(crate) struct CachedGrassChunk {
     pub explicit_xz_buffer: Option<Buffer>,
     pub explicit_count: u32,
-    pub dither_handle: Option<Handle<DitheredBuffer>>,
 }
 #[derive(Resource, Default)]
 pub(crate) struct UniformBuffer(pub Option<BindGroup>);

--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -17,10 +17,6 @@ pub(crate) struct CachedGrassChunk {
     pub explicit_xz_buffer: Option<Buffer>,
     pub explicit_count: u32,
     pub dither_handle: Option<Handle<DitheredBuffer>>,
-    pub height_map: Option<BindGroup>,
-    pub explicit_y_buffer: Option<BindGroup>,
-    pub height_buffer: Option<BindGroup>,
-    pub blade_height_texture: Option<BindGroup>,
 }
 
 #[derive(Resource, DerefMut, Deref, Debug, Default)]

--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -1,7 +1,7 @@
 use bevy::{
     prelude::*,
     render::render_resource::{BindGroup, Buffer},
-    utils::{HashMap, HashSet},
+    utils::HashMap,
 };
 
 use crate::dithering::DitheredBuffer;
@@ -17,9 +17,4 @@ pub(crate) struct CachedGrassChunk {
     pub explicit_xz_buffer: Option<Buffer>,
     pub explicit_count: u32,
     pub dither_handle: Option<Handle<DitheredBuffer>>,
-}
-
-#[derive(Resource, DerefMut, Deref, Debug, Default)]
-pub struct EntityCache {
-    pub entities: HashSet<Entity>,
 }

--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -21,7 +21,6 @@ pub(crate) struct CachedGrassChunk {
     pub explicit_y_buffer: Option<BindGroup>,
     pub height_buffer: Option<BindGroup>,
     pub blade_height_texture: Option<BindGroup>,
-    pub transform: GlobalTransform,
 }
 
 #[derive(Resource, DerefMut, Deref, Debug, Default)]

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -13,25 +13,22 @@ use bevy::{
 
 use crate::{dithering::DitheredBuffer, height_map::HeightMap, prelude::WarblerHeight};
 
-use super::{cache::GrassCache, prepare::BindGroupBuffer};
+use super::{cache::{GrassCache, UniformBuffer}, prepare::BindGroupBuffer};
 pub(crate) struct SetUniformBindGroup<const I: usize>;
 
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetUniformBindGroup<I> {
-    type Param = SRes<GrassCache>;
+    type Param = SRes<UniformBuffer>;
     type ViewWorldQuery = ();
     type ItemWorldQuery = ();
 
     fn render<'w>(
-        item: &P,
+        _item: &P,
         _view: (),
         _entity: (),
         cache: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let Some(chunk) = cache.into_inner().get(&item.entity()) else {
-            return RenderCommandResult::Failure;
-        };
-        pass.set_bind_group(I, chunk.uniform_bindgroup.as_ref().unwrap(), &[]);
+        pass.set_bind_group(I, cache.into_inner().ref_unwrap(), &[]);
 
         RenderCommandResult::Success
     }
@@ -50,18 +47,6 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetYBindGroup<I> {
         _cache: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        // let Some(chunk) = cache.into_inner().get(&item.entity()) else {
-        //     return RenderCommandResult::Failure;
-        // };
-        // if let Some(height_map) = chunk.height_map.as_ref() {
-        //     pass.set_bind_group(I, height_map, &[]);
-        //     return RenderCommandResult::Success;
-        // }
-        // if let Some(y_buffer) = chunk.explicit_y_buffer.as_ref() {
-        //     pass.set_bind_group(I, y_buffer, &[]);
-        //     return RenderCommandResult::Success;
-        // }
-        // RenderCommandResult::Failure
         let Some(bind_group) = bind_group else {
             println!("couldn't find bind group buffer height map");
             return RenderCommandResult::Failure;

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -11,9 +11,9 @@ use bevy::{
     },
 };
 
-use crate::dithering::DitheredBuffer;
+use crate::{dithering::DitheredBuffer, prelude::WarblerHeight, bundle};
 
-use super::cache::GrassCache;
+use super::{cache::GrassCache, prepare::BindGroupBuffer};
 pub(crate) struct SetUniformBindGroup<const I: usize>;
 
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetUniformBindGroup<I> {
@@ -67,29 +67,22 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetYBindGroup<I> {
 pub(crate) struct SetHeightBindGroup<const I: usize>;
 
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetHeightBindGroup<I> {
-    type Param = SRes<GrassCache>;
+    type Param = ();
     type ViewWorldQuery = ();
-    type ItemWorldQuery = ();
+    type ItemWorldQuery = Read<BindGroupBuffer::<WarblerHeight>>;
 
     fn render<'w>(
-        item: &P,
+        _item: &P,
         _view: (),
-        _entity: (),
-        cache: SystemParamItem<'w, '_, Self::Param>,
+        height: &'w BindGroupBuffer<WarblerHeight>,
+        _param: (),
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let Some(chunk) = cache.into_inner().get(&item.entity()) else {
-            return RenderCommandResult::Failure;
-        };
-        if let Some(height_buffer) = chunk.height_buffer.as_ref() {
-            pass.set_bind_group(I, height_buffer, &[]);
-            return RenderCommandResult::Success;
-        }
-        if let Some(height_buffer) = chunk.blade_height_texture.as_ref() {
-            pass.set_bind_group(I, height_buffer, &[]);
-            return RenderCommandResult::Success;
-        }
-        RenderCommandResult::Failure
+
+        pass.set_bind_group(I,&height.bind_group, &[]);
+
+   
+        RenderCommandResult::Success
     }
 }
 pub(crate) struct SetVertexBuffer;

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -87,13 +87,16 @@ impl<P: PhaseItem> RenderCommand<P> for SetVertexBuffer {
         SRes<RenderAssets<DitheredBuffer>>,
     );
     type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<Handle<Mesh>>;
+    type ItemWorldQuery = (Read<Handle<Mesh>>, Option<Read<Handle<DitheredBuffer>>>);
 
     #[inline]
     fn render<'w>(
         item: &P,
         _view: (),
-        mesh_handle: &'w Handle<bevy::prelude::Mesh>,
+        (mesh_handle, dither_handle): (
+            &'w Handle<bevy::prelude::Mesh>,
+            Option<&'w Handle<DitheredBuffer>>,
+        ),
         (meshes, cache, dither): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -107,7 +110,7 @@ impl<P: PhaseItem> RenderCommand<P> for SetVertexBuffer {
         pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
         let blade_count;
 
-        if let Some(dither_handle) = chunk.dither_handle.as_ref() {
+        if let Some(dither_handle) = dither_handle {
             if let Some(gpu_dither) = dither.into_inner().get(dither_handle) {
                 blade_count = gpu_dither.instances as u32;
                 if blade_count == 0 {

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -104,7 +104,7 @@ impl<P: PhaseItem> RenderCommand<P> for SetVertexBuffer {
             Some(gpu_mesh) => gpu_mesh,
             None => return RenderCommandResult::Failure,
         };
-        
+
         pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
         let blade_count;
 

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -13,7 +13,10 @@ use bevy::{
 
 use crate::{dithering::DitheredBuffer, height_map::HeightMap, prelude::WarblerHeight};
 
-use super::{cache::{GrassCache, UniformBuffer}, prepare::BindGroupBuffer};
+use super::{
+    cache::{GrassCache, UniformBuffer},
+    prepare::BindGroupBuffer,
+};
 pub(crate) struct SetUniformBindGroup<const I: usize>;
 
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetUniformBindGroup<I> {

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -11,7 +11,7 @@ use bevy::{
     },
 };
 
-use crate::{dithering::DitheredBuffer, prelude::WarblerHeight, height_map::HeightMap};
+use crate::{dithering::DitheredBuffer, height_map::HeightMap, prelude::WarblerHeight};
 
 use super::{cache::GrassCache, prepare::BindGroupBuffer};
 pub(crate) struct SetUniformBindGroup<const I: usize>;
@@ -41,7 +41,7 @@ pub(crate) struct SetYBindGroup<const I: usize>;
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetYBindGroup<I> {
     type Param = ();
     type ViewWorldQuery = ();
-    type ItemWorldQuery = Option<Read<BindGroupBuffer::<HeightMap>>>;
+    type ItemWorldQuery = Option<Read<BindGroupBuffer<HeightMap>>>;
 
     fn render<'w>(
         _item: &P,
@@ -69,8 +69,6 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetYBindGroup<I> {
         };
         pass.set_bind_group(I, &bind_group.bind_group, &[]);
         return RenderCommandResult::Success;
-
-
     }
 }
 pub(crate) struct SetHeightBindGroup<const I: usize>;
@@ -78,7 +76,7 @@ pub(crate) struct SetHeightBindGroup<const I: usize>;
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetHeightBindGroup<I> {
     type Param = ();
     type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<BindGroupBuffer::<WarblerHeight>>;
+    type ItemWorldQuery = Read<BindGroupBuffer<WarblerHeight>>;
 
     fn render<'w>(
         _item: &P,
@@ -87,10 +85,8 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetHeightBindGroup<I> {
         _param: (),
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
+        pass.set_bind_group(I, &height.bind_group, &[]);
 
-        pass.set_bind_group(I,&height.bind_group, &[]);
-
-   
         RenderCommandResult::Success
     }
 }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,6 +1,6 @@
 use super::cache::{CachedGrassChunk, EntityCache, GrassCache};
 use crate::{
-    bundle::{Grass, WarblerHeight},
+    bundle::Grass,
     dithering::DitheredBuffer,
 };
 use bevy::{
@@ -17,14 +17,14 @@ pub(crate) fn extract_grass(
     mut commands: Commands,
     grass_spawner: Extract<
         Query<
-            (Entity, &Handle<DitheredBuffer>, &WarblerHeight, &Aabb),
-            Or<(Changed<Handle<DitheredBuffer>>, Changed<WarblerHeight>)>,
+            (Entity, &Handle<DitheredBuffer>, &Aabb),
+            Changed<Handle<DitheredBuffer>>,
         >,
     >,
     mut grass_cache: ResMut<GrassCache>,
 ) {
     let mut values = Vec::new();
-    for (entity, dithered, height, aabb) in grass_spawner.iter() {
+    for (entity, dithered, aabb) in grass_spawner.iter() {
         let cache_value = grass_cache.entry(entity).or_default();
         cache_value.dither_handle = Some(dithered.clone());
         values.push((
@@ -32,7 +32,6 @@ pub(crate) fn extract_grass(
             (
                 EntityStorage(entity),
                 dithered.clone(),
-                height.clone(),
                 *aabb,
             ),
         ));

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,8 +1,5 @@
-use super::cache::{CachedGrassChunk, EntityCache, GrassCache};
-use crate::{
-    bundle::Grass,
-    dithering::DitheredBuffer, height_map::HeightMap,
-};
+use super::cache::{CachedGrassChunk, GrassCache};
+use crate::{bundle::Grass, dithering::DitheredBuffer, height_map::HeightMap};
 use bevy::{
     prelude::*,
     render::{primitives::Aabb, Extract},
@@ -16,10 +13,7 @@ use bevy::{
 pub(crate) fn extract_grass(
     mut commands: Commands,
     grass_spawner: Extract<
-        Query<
-            (Entity, &Handle<DitheredBuffer>, &Aabb),
-            Changed<Handle<DitheredBuffer>>,
-        >,
+        Query<(Entity, &Handle<DitheredBuffer>, &Aabb), Changed<Handle<DitheredBuffer>>>,
     >,
     mut grass_cache: ResMut<GrassCache>,
 ) {
@@ -27,13 +21,7 @@ pub(crate) fn extract_grass(
     for (entity, dithered, aabb) in grass_spawner.iter() {
         let cache_value = grass_cache.entry(entity).or_default();
         cache_value.dither_handle = Some(dithered.clone());
-        values.push((
-            entity,
-            (
-                dithered.clone(),
-                *aabb,
-            ),
-        ));
+        values.push((entity, (dithered.clone(), *aabb)));
     }
     commands.insert_or_spawn_batch(values);
 }
@@ -44,9 +32,11 @@ pub(crate) fn extract_grass(
 #[allow(clippy::type_complexity)]
 pub(crate) fn extract_grass_positions(
     mut commands: Commands,
-    grass_spawner: Extract<Query<(Entity, &Grass, &Aabb)
-    // , Or<(Changed<Grass>, Changed<Aabb>)>
-    >>,
+    grass_spawner: Extract<
+        Query<
+            (Entity, &Grass, &Aabb), // , Or<(Changed<Grass>, Changed<Aabb>)>
+        >,
+    >,
     mut grass_cache: ResMut<GrassCache>,
 ) {
     let mut values = Vec::new();
@@ -60,36 +50,12 @@ pub(crate) fn extract_grass_positions(
     commands.insert_or_spawn_batch(values);
 }
 
-
-/// Extracts all visible grass entities into the render world
-#[allow(clippy::type_complexity)]
-pub(crate) fn extract_visibility(
-    visibility_queue: Extract<
-        Query<
-            (Entity, &ComputedVisibility),
-            (
-                Or<(With<Handle<DitheredBuffer>>, With<Grass>)>,
-                With<Transform>,
-            ),
-        >,
-    >,
-    mut entity_cache: ResMut<EntityCache>,
-) {
-    entity_cache.entities = visibility_queue
-        .iter()
-        .filter_map(|(e, visibility)| visibility.is_visible().then_some(e))
-        .collect();
-}
 pub(crate) fn extract_aabb(
     mut commands: Commands,
-
-    aabbs: Extract<
-    Query<(Entity, &Aabb), With<HeightMap>>
-    >
+    aabbs: Extract<Query<(Entity, &Aabb), With<HeightMap>>>,
 ) {
-
     let mut values = Vec::new();
-    for (e,aabb) in aabbs.iter() {
+    for (e, aabb) in aabbs.iter() {
         values.push((e, *aabb));
     }
     commands.insert_or_spawn_batch(values);

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -32,11 +32,7 @@ pub(crate) fn extract_grass(
 #[allow(clippy::type_complexity)]
 pub(crate) fn extract_grass_positions(
     mut commands: Commands,
-    grass_spawner: Extract<
-        Query<
-            (Entity, &Grass, &Aabb), // , Or<(Changed<Grass>, Changed<Aabb>)>
-        >,
-    >,
+    grass_spawner: Extract<Query<(Entity, &Grass, &Aabb)>>,
     mut grass_cache: ResMut<GrassCache>,
 ) {
     let mut values = Vec::new();

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,4 +1,4 @@
-use super::cache::{CachedGrassChunk, GrassCache};
+use super::cache::{CachedExplicitGrassChunk, ExplicitGrassCache};
 use crate::{bundle::Grass, dithering::DitheredBuffer, height_map::HeightMap};
 use bevy::{
     prelude::*,
@@ -28,13 +28,13 @@ pub(crate) fn extract_grass(
 pub(crate) fn extract_grass_positions(
     mut commands: Commands,
     grass_spawner: Extract<Query<(Entity, &Grass, &Aabb)>>,
-    mut grass_cache: ResMut<GrassCache>,
+    mut grass_cache: ResMut<ExplicitGrassCache>,
 ) {
     let mut values = Vec::new();
 
     for (entity, grass, aabb) in grass_spawner.iter() {
         if !grass_cache.contains_key(&entity) {
-            grass_cache.insert(entity, CachedGrassChunk::default());
+            grass_cache.insert(entity, CachedExplicitGrassChunk::default());
         }
         values.push((entity, (grass.clone(), *aabb)));
     }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -12,15 +12,10 @@ use bevy::{
 #[allow(clippy::type_complexity)]
 pub(crate) fn extract_grass(
     mut commands: Commands,
-    grass_spawner: Extract<
-        Query<(Entity, &Handle<DitheredBuffer>, &Aabb), Changed<Handle<DitheredBuffer>>>,
-    >,
-    mut grass_cache: ResMut<GrassCache>,
+    grass_spawner: Extract<Query<(Entity, &Handle<DitheredBuffer>, &Aabb)>>,
 ) {
     let mut values = Vec::new();
     for (entity, dithered, aabb) in grass_spawner.iter() {
-        let cache_value = grass_cache.entry(entity).or_default();
-        cache_value.dither_handle = Some(dithered.clone());
         values.push((entity, (dithered.clone(), *aabb)));
     }
     commands.insert_or_spawn_batch(values);

--- a/src/render/grass_pipeline.rs
+++ b/src/render/grass_pipeline.rs
@@ -224,6 +224,7 @@ impl SpecializedMeshPipeline for GrassPipeline {
         }
 
         if key.uniform_height {
+            println!("uniform height");
             descriptor.layout.push(self.uniform_height_layout.clone());
         } else {
             vertex.shader_defs.push("HEIGHT_TEXTURE".into());

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -7,7 +7,7 @@ use super::cache::UniformBuffer;
 use super::grass_pipeline::GrassPipeline;
 use crate::bundle::{Grass, WarblerHeight};
 use crate::height_map::HeightMap;
-use crate::render::cache::GrassCache;
+use crate::render::cache::ExplicitGrassCache;
 use crate::{GrassConfiguration, GrassNoiseTexture};
 use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
@@ -37,7 +37,7 @@ impl<T> BindGroupBuffer<T> {
 }
 pub(crate) fn prepare_explicit_positions_buffer(
     mut commands: Commands,
-    mut cache: ResMut<GrassCache>,
+    mut cache: ResMut<ExplicitGrassCache>,
     pipeline: Res<GrassPipeline>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -2,7 +2,6 @@ use std::mem;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::ops::Mul;
 
-use super::extract::EntityStorage;
 use super::grass_pipeline::GrassPipeline;
 use crate::bundle::{Grass, WarblerHeight};
 use crate::height_map::HeightMap;
@@ -27,10 +26,10 @@ pub(crate) fn prepare_explicit_positions_buffer(
     pipeline: Res<GrassPipeline>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
-    mut inserted_grass: Query<(&mut Grass, &EntityStorage)>,
+    mut inserted_grass: Query<(Entity, &mut Grass)>,
 ) {
-    for (grass, EntityStorage(id)) in inserted_grass.iter_mut() {
-        if let Some(chunk) = cache.get_mut(id) {
+    for (id, grass) in inserted_grass.iter_mut() {
+        if let Some(chunk) = cache.get_mut(&id) {
             chunk.explicit_count = grass.positions.len() as u32;
             let (xz, mut y): (Vec<Vec2>, Vec<f32>) =
                 grass.positions.iter().map(|v| (v.xz(), v.y)).unzip();
@@ -95,12 +94,12 @@ pub(crate) fn prepare_height_buffer(
     images: Res<RenderAssets<Image>>,
 
     render_device: Res<RenderDevice>,
-    inserted_grass: Query<(&EntityStorage, &WarblerHeight)>,
-    mut local_height_map_storage: Local<Vec<(EntityStorage, Handle<Image>)>>,
+    inserted_grass: Query<(Entity, &WarblerHeight)>,
+    mut local_height_map_storage: Local<Vec<(Entity, Handle<Image>)>>,
 ) {
     let stored = std::mem::take(&mut *local_height_map_storage);
-    for (entity_storage, heights_texture) in stored.into_iter() {
-        if let Some(chunk) = cache.get_mut(&entity_storage.0) {
+    for (entity, heights_texture) in stored.into_iter() {
+        if let Some(chunk) = cache.get_mut(&entity) {
             let layout = pipeline.heights_texture_layout.clone();
             if let Some(tex) = images.get(&heights_texture) {
                 let bind_group_descriptor = BindGroupDescriptor {
@@ -115,13 +114,12 @@ pub(crate) fn prepare_height_buffer(
                 let bind_group = render_device.create_bind_group(&bind_group_descriptor);
                 chunk.blade_height_texture = Some(bind_group);
             } else {
-                local_height_map_storage.push((entity_storage, heights_texture));
+                local_height_map_storage.push((entity, heights_texture));
             }
         }
     }
-    for (entity_storage, height) in inserted_grass.iter() {
-        let id = &entity_storage.0;
-        if let Some(chunk) = cache.get_mut(id) {
+    for (entity, height) in inserted_grass.iter() {
+        if let Some(chunk) = cache.get_mut(&entity) {
             match height.clone() {
                 WarblerHeight::Uniform(height) => {
                     let layout = pipeline.uniform_height_layout.clone();
@@ -156,7 +154,7 @@ pub(crate) fn prepare_height_buffer(
                     } else {
                         // if the texture is not loaded, we will push it locally and try next frame again
                         local_height_map_storage
-                            .push((entity_storage.clone(), heights_texture.clone()));
+                            .push((entity, heights_texture.clone()));
 
                         &fallback_img.texture_view
                     };
@@ -188,13 +186,13 @@ pub(crate) fn prepare_height_map_buffer(
     pipeline: Res<GrassPipeline>,
     fallback_img: Res<FallbackImage>,
     images: Res<RenderAssets<Image>>,
-    inserted_grass: Query<(&HeightMap, &EntityStorage, &Aabb)>,
-    mut local_height_map_storage: Local<Vec<(EntityStorage, Handle<Image>, Aabb)>>,
+    inserted_grass: Query<(Entity, &HeightMap,&Aabb)>,
+    mut local_height_map_storage: Local<Vec<(Entity, Handle<Image>, Aabb)>>,
 ) {
     let mut has_loaded = Vec::new();
     let layout = pipeline.height_map_layout.clone();
 
-    for (EntityStorage(e), handle, aabb) in local_height_map_storage.iter() {
+    for (e, handle, aabb) in local_height_map_storage.iter() {
         if let Some(tex) = images.get(handle) {
             has_loaded.push(*e);
             let height_map_texture = &tex.texture_view;
@@ -230,16 +228,15 @@ pub(crate) fn prepare_height_map_buffer(
             }
         }
     }
-    local_height_map_storage.retain(|map| !has_loaded.contains(&map.0 .0));
+    local_height_map_storage.retain(|(e,_,_)| !has_loaded.contains(e));
 
-    for (height_map, entity_store, aabb) in inserted_grass.iter() {
-        let id = entity_store.0;
+    for (entity, height_map, aabb) in inserted_grass.iter() {
         let height_map_texture = if let Some(tex) = images.get(&height_map.height_map) {
             &tex.texture_view
         } else {
             // if the texture is not loaded, we will push it locally and try next frame again
             local_height_map_storage.push((
-                entity_store.clone(),
+                entity,
                 height_map.height_map.clone(),
                 *aabb,
             ));
@@ -272,7 +269,7 @@ pub(crate) fn prepare_height_map_buffer(
         };
 
         let bind_group = render_device.create_bind_group(&bind_group_descriptor);
-        if let Some(chunk) = cache.get_mut(&id) {
+        if let Some(chunk) = cache.get_mut(&entity) {
             chunk.height_map = Some(bind_group);
         } else {
             warn!("Tried to prepare a buffer for a grass chunk which wasn't registered before");

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -3,6 +3,7 @@ use std::mem;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::ops::Mul;
 
+use super::cache::UniformBuffer;
 use super::grass_pipeline::GrassPipeline;
 use crate::bundle::{Grass, WarblerHeight};
 use crate::height_map::HeightMap;
@@ -223,11 +224,11 @@ pub(crate) fn prepare_height_map_buffer(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn prepare_uniform_buffers(
     pipeline: Res<GrassPipeline>,
-    mut cache: ResMut<GrassCache>,
     region_config: Res<GrassConfiguration>,
     noise_config: Res<GrassNoiseTexture>,
     fallback_img: Res<FallbackImage>,
     render_device: Res<RenderDevice>,
+    mut uniform_buffer: ResMut<UniformBuffer>,
     images: Res<RenderAssets<Image>>,
     mut last_texture_id: Local<Option<TextureViewId>>,
 ) {
@@ -267,10 +268,7 @@ pub(crate) fn prepare_uniform_buffers(
         ],
     };
     let bind_group = render_device.create_bind_group(&bind_group_descriptor);
-
-    for instance_data in cache.values_mut() {
-        instance_data.uniform_bindgroup = Some(bind_group.clone());
-    }
+    uniform_buffer.set(bind_group);
 }
 
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -6,6 +6,9 @@ use bevy::render::render_phase::{DrawFunctions, RenderPhase};
 use bevy::render::render_resource::{PipelineCache, SpecializedMeshPipelines};
 use bevy::render::view::ExtractedView;
 
+use crate::dithering::DitheredBuffer;
+use crate::prelude::Grass;
+
 use super::cache::ExplicitGrassCache;
 use super::grass_pipeline::{GrassPipeline, GrassRenderKey};
 use super::prepare::UniformHeightFlag;
@@ -25,7 +28,7 @@ pub(crate) fn queue_grass_buffers(
         &MeshUniform,
         &Handle<Mesh>,
         Option<&UniformHeightFlag>,
-    )>,
+    ), Or<(With<Grass>, With<Handle<DitheredBuffer>>)>>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Opaque3d>)>,
 ) {
     let draw_custom = opaque_3d_draw_functions

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -9,6 +9,7 @@ use bevy::render::view::ExtractedView;
 use super::cache::GrassCache;
 use super::grass_pipeline::{GrassPipeline, GrassRenderKey};
 use super::GrassDrawCall;
+use super::prepare::UniformHeightFlag;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn queue_grass_buffers(
@@ -19,7 +20,7 @@ pub(crate) fn queue_grass_buffers(
     pipeline_cache: Res<PipelineCache>,
     grass_cacher: Res<GrassCache>,
     meshes: Res<RenderAssets<Mesh>>,
-    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>)>,
+    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>, Option<&UniformHeightFlag>)>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Opaque3d>)>,
 ) {
     let draw_custom = opaque_3d_draw_functions
@@ -32,16 +33,16 @@ pub(crate) fn queue_grass_buffers(
     for (view, mut opaque_phase) in &mut views {
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let rangefinder = view.rangefinder3d();
-        for (entity, mesh_uniform, mesh_handle) in material_meshes
+        for (entity, mesh_uniform, mesh_handle, has_uniform_height) in material_meshes
             .iter()
-            .filter(|(e, _, _)| grass_cacher.contains_key(e))
+            .filter(|(e, _, _, _)| grass_cacher.contains_key(e))
         {
             if let Some(mesh) = meshes.get(mesh_handle) {
                 let mesh_key =
                     view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
                 let mut grass_key = GrassRenderKey::from(mesh_key);
                 grass_key.is_explicit = grass_cacher[&entity].explicit_xz_buffer.is_some();
-                grass_key.uniform_height = grass_cacher[&entity].blade_height_texture.is_none();
+                grass_key.uniform_height = has_uniform_height.is_some();
                 let pipeline = pipelines
                     .specialize(&pipeline_cache, &grass_pipeline, grass_key, &mesh.layout)
                     .unwrap();

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -8,8 +8,8 @@ use bevy::render::view::ExtractedView;
 
 use super::cache::GrassCache;
 use super::grass_pipeline::{GrassPipeline, GrassRenderKey};
-use super::GrassDrawCall;
 use super::prepare::UniformHeightFlag;
+use super::GrassDrawCall;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn queue_grass_buffers(
@@ -20,7 +20,12 @@ pub(crate) fn queue_grass_buffers(
     pipeline_cache: Res<PipelineCache>,
     grass_cacher: Res<GrassCache>,
     meshes: Res<RenderAssets<Mesh>>,
-    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>, Option<&UniformHeightFlag>)>,
+    material_meshes: Query<(
+        Entity,
+        &MeshUniform,
+        &Handle<Mesh>,
+        Option<&UniformHeightFlag>,
+    )>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Opaque3d>)>,
 ) {
     let draw_custom = opaque_3d_draw_functions

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -23,12 +23,15 @@ pub(crate) fn queue_grass_buffers(
     pipeline_cache: Res<PipelineCache>,
     grass_cacher: Res<ExplicitGrassCache>,
     meshes: Res<RenderAssets<Mesh>>,
-    material_meshes: Query<(
-        Entity,
-        &MeshUniform,
-        &Handle<Mesh>,
-        Option<&UniformHeightFlag>,
-    ), Or<(With<Grass>, With<Handle<DitheredBuffer>>)>>,
+    material_meshes: Query<
+        (
+            Entity,
+            &MeshUniform,
+            &Handle<Mesh>,
+            Option<&UniformHeightFlag>,
+        ),
+        Or<(With<Grass>, With<Handle<DitheredBuffer>>)>,
+    >,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Opaque3d>)>,
 ) {
     let draw_custom = opaque_3d_draw_functions
@@ -41,9 +44,7 @@ pub(crate) fn queue_grass_buffers(
     for (view, mut opaque_phase) in &mut views {
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let rangefinder = view.rangefinder3d();
-        for (entity, mesh_uniform, mesh_handle, has_uniform_height) in material_meshes
-            .iter()
-        {
+        for (entity, mesh_uniform, mesh_handle, has_uniform_height) in material_meshes.iter() {
             if let Some(mesh) = meshes.get(mesh_handle) {
                 let mesh_key =
                     view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -20,7 +20,13 @@ use crate::{
     dithering::{add_dither_to_density, DitheredBuffer},
     height_map::HeightMap,
     prelude::WarblerHeight,
-    render::{self, cache::GrassCache, extract, grass_pipeline::GrassPipeline, prepare, queue},
+    render::{
+        self,
+        cache::{GrassCache, UniformBuffer},
+        extract,
+        grass_pipeline::GrassPipeline,
+        prepare, queue,
+    },
     update, GrassConfiguration, GrassNoiseTexture,
 };
 
@@ -71,6 +77,7 @@ impl Plugin for WarblersPlugin {
             .add_render_command::<Opaque3d, render::GrassDrawCall>()
             .init_resource::<FallbackImage>()
             .init_resource::<GrassPipeline>()
+            .init_resource::<UniformBuffer>()
             .init_resource::<GrassCache>()
             .init_resource::<SpecializedMeshPipelines<GrassPipeline>>()
             .add_systems(

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -83,6 +83,7 @@ impl Plugin for WarblersPlugin {
                 (
                     extract::extract_grass,
                     extract::extract_visibility,
+                    extract::extract_aabb,
                     extract::extract_grass_positions,
                 )
                     .in_schedule(ExtractSchedule),

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -22,7 +22,7 @@ use crate::{
     prelude::WarblerHeight,
     render::{
         self,
-        cache::{GrassCache, UniformBuffer},
+        cache::{ExplicitGrassCache, UniformBuffer},
         extract,
         grass_pipeline::GrassPipeline,
         prepare, queue,
@@ -78,7 +78,7 @@ impl Plugin for WarblersPlugin {
             .init_resource::<FallbackImage>()
             .init_resource::<GrassPipeline>()
             .init_resource::<UniformBuffer>()
-            .init_resource::<GrassCache>()
+            .init_resource::<ExplicitGrassCache>()
             .init_resource::<SpecializedMeshPipelines<GrassPipeline>>()
             .add_systems(
                 (

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -5,6 +5,7 @@ use bevy::{
     prelude::*,
     reflect::TypeUuid,
     render::{
+        extract_component::ExtractComponentPlugin,
         extract_resource::ExtractResourcePlugin,
         mesh::{Indices, Mesh},
         render_asset::RenderAssetPlugin,
@@ -17,6 +18,7 @@ use bevy::{
 
 use crate::{
     dithering::{add_dither_to_density, DitheredBuffer},
+    height_map::HeightMap,
     render::{
         self,
         cache::{EntityCache, GrassCache},
@@ -67,6 +69,7 @@ impl Plugin for WarblersPlugin {
         // Add extraction of the configuration
         app.add_plugin(ExtractResourcePlugin::<GrassConfiguration>::default());
         app.add_plugin(ExtractResourcePlugin::<GrassNoiseTexture>::default());
+        app.add_plugin(ExtractComponentPlugin::<HeightMap>::extract_visible());
         // Init render app
         app.sub_app_mut(RenderApp)
             .add_render_command::<Opaque3d, render::GrassDrawCall>()

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -26,7 +26,7 @@ use crate::{
         grass_pipeline::GrassPipeline,
         prepare, queue,
     },
-    update, GrassConfiguration, GrassNoiseTexture,
+    update, GrassConfiguration, GrassNoiseTexture, prelude::WarblerHeight,
 };
 
 /// A raw handle which points to the shader used to render the grass.
@@ -69,7 +69,8 @@ impl Plugin for WarblersPlugin {
         // Add extraction of the configuration
         app.add_plugin(ExtractResourcePlugin::<GrassConfiguration>::default());
         app.add_plugin(ExtractResourcePlugin::<GrassNoiseTexture>::default());
-        app.add_plugin(ExtractComponentPlugin::<HeightMap>::extract_visible());
+        app.add_plugin(ExtractComponentPlugin::<HeightMap>::default());
+        app.add_plugin(ExtractComponentPlugin::<WarblerHeight>::default());
         // Init render app
         app.sub_app_mut(RenderApp)
             .add_render_command::<Opaque3d, render::GrassDrawCall>()

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -19,14 +19,9 @@ use bevy::{
 use crate::{
     dithering::{add_dither_to_density, DitheredBuffer},
     height_map::HeightMap,
-    render::{
-        self,
-        cache::{EntityCache, GrassCache},
-        extract,
-        grass_pipeline::GrassPipeline,
-        prepare, queue,
-    },
-    update, GrassConfiguration, GrassNoiseTexture, prelude::WarblerHeight,
+    prelude::WarblerHeight,
+    render::{self, cache::GrassCache, extract, grass_pipeline::GrassPipeline, prepare, queue},
+    update, GrassConfiguration, GrassNoiseTexture,
 };
 
 /// A raw handle which points to the shader used to render the grass.
@@ -77,12 +72,10 @@ impl Plugin for WarblersPlugin {
             .init_resource::<FallbackImage>()
             .init_resource::<GrassPipeline>()
             .init_resource::<GrassCache>()
-            .init_resource::<EntityCache>()
             .init_resource::<SpecializedMeshPipelines<GrassPipeline>>()
             .add_systems(
                 (
                     extract::extract_grass,
-                    extract::extract_visibility,
                     extract::extract_aabb,
                     extract::extract_grass_positions,
                 )


### PR DESCRIPTION
# Conclusion
The pipeline now looks way more clean.
The performance didn't show any loss,
I think this is simply because most of the caching was simply unneeded as some cached values were so tiny that simply no overhead is implied by calculating them in real time

## Performance notes:
### Stresstest:
| Value | Before | After |
| --- | --- | --- | 
| mean time per frame | 19.81 | 18.67|
| median time per frame | 17.06 | 17.09 |

### Many chunks
| Value | Before | After |
| --- | --- | --- | 
| mean time per frame | 18.2 | 18.66|
| median time per frame | 16.68 | 16.58 |