### PR TITLE
Respect prepasses instead of crashing

### DIFF
--- a/src/render/assets/grass_shader.wgsl
+++ b/src/render/assets/grass_shader.wgsl
@@ -1,6 +1,5 @@
 #import bevy_pbr::mesh_functions::{mesh_position_local_to_clip, get_model_matrix}
 #import bevy_pbr::mesh_types::Mesh
-// #import bevy_pbr::mesh_view_bindings::globals
 #import bevy_pbr::mesh_bindings::mesh
 #import bevy_render::maths::affine_to_square
 

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -1,4 +1,7 @@
 use bevy::core_pipeline::core_3d::Opaque3d;
+use bevy::core_pipeline::prepass::{
+    DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass,
+};
 use bevy::pbr::{MeshPipelineKey, RenderMeshInstances};
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssets;
@@ -21,41 +24,60 @@ pub(crate) fn queue_grass_buffers(
     render_mesh_instances: Res<RenderMeshInstances>,
     meshes: Res<RenderAssets<Mesh>>,
     material_meshes: Query<(Entity, &WarblerHeight)>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<Opaque3d>)>,
+    mut views: Query<(
+        &ExtractedView,
+        &mut RenderPhase<Opaque3d>,
+        Has<DepthPrepass>,
+        Has<NormalPrepass>,
+        Has<MotionVectorPrepass>,
+        Has<DeferredPrepass>,
+    )>,
 ) {
-    let draw_custom = opaque_3d_draw_functions
-        .read()
-        .get_id::<GrassDrawCall>()
-        .unwrap();
+    let draw_custom = opaque_3d_draw_functions.read().id::<GrassDrawCall>();
     let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
 
-    for (view, mut opaque_phase) in &mut views {
-        let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
+    for (view, mut opaque_phase, depth_prepass, normal_prepass, motion_prepass, deferred_prepass) in
+        &mut views
+    {
+        let mut view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
+        if deferred_prepass {
+            view_key |= MeshPipelineKey::DEFERRED_PREPASS;
+        }
+        if depth_prepass {
+            view_key |= MeshPipelineKey::DEPTH_PREPASS;
+        }
+        if normal_prepass {
+            view_key |= MeshPipelineKey::NORMAL_PREPASS;
+        }
+        if motion_prepass {
+            view_key |= MeshPipelineKey::MOTION_VECTOR_PREPASS;
+        }
         for (entity, height) in material_meshes.iter() {
             let Some(mesh_instance) = render_mesh_instances.get(&entity) else {
                 continue;
             };
 
-            if let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) {
-                let mesh_key =
-                    view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                let mut grass_key = GrassRenderKey::from(mesh_key);
-                grass_key.uniform_height = match height {
-                    WarblerHeight::Uniform(_) => true,
-                    WarblerHeight::Texture(_) => false,
-                };
-                let pipeline = pipelines
-                    .specialize(&pipeline_cache, &grass_pipeline, grass_key, &mesh.layout)
-                    .unwrap();
-                opaque_phase.add(Opaque3d {
-                    entity,
-                    pipeline,
-                    draw_function: draw_custom,
-                    batch_range: 0..1,
-                    dynamic_offset: None,
-                    asset_id: mesh_instance.mesh_asset_id,
-                });
-            }
+            let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) else {
+                continue;
+            };
+            let mesh_key =
+                view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+            let mut grass_key = GrassRenderKey::from(mesh_key);
+            grass_key.uniform_height = match height {
+                WarblerHeight::Uniform(_) => true,
+                WarblerHeight::Texture(_) => false,
+            };
+            let pipeline = pipelines
+                .specialize(&pipeline_cache, &grass_pipeline, grass_key, &mesh.layout)
+                .unwrap();
+            opaque_phase.add(Opaque3d {
+                entity,
+                pipeline,
+                draw_function: draw_custom,
+                batch_range: 0..1,
+                dynamic_offset: None,
+                asset_id: mesh_instance.mesh_asset_id,
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes #84 
Turns out all prepasses had problems with the current implementation.
If any prepass was attached to a view object, the project crashed while trying to render grass.
This includes `DepthPrepass, NormalPrepass, MotionVectorPrepass, DeferredPrepass`.

The new implementation doesn't crash the app but also doesn't draw to any `Prepass` as of now. Writing to the depth or normal buffer would make rendering of the grass unproportionally expensive AFAIK and isn't common practice in other vegetation pipelines. 
I am open to merge a optional solution if someone were to make a PR 