### PR TITLE
Dither speedup and async loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bitflags = "2"
 [dependencies.bevy]
 version = "0.13"
 default-features = false
-features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr" , "png"]
+features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr" , "png", "multi-threaded"]
 
 [dev-dependencies]
 bevy = { version = "0.13", default-features = false, features = ["bevy_winit","x11", "ktx2", "zstd", "tonemapping_luts", "multi-threaded"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ description = "A bevy plugin for creating 3d grass in your game"
 [dependencies]
 bytemuck = "1.13.0"
 bitflags = "2"
+image = "0.24.9" # needs to be in sync with the version used by bevy
 [dependencies.bevy]
 version = "0.13"
 default-features = false

--- a/src/dithering.rs
+++ b/src/dithering.rs
@@ -173,6 +173,9 @@ pub(crate) fn add_dither_task(
                 }
                 Err(error) => {
                     command_queue.push(move |world: &mut World| {
+                        if let Some(mut entity_builder) = world.get_entity_mut(e) {
+                            entity_builder.remove::<ComputeDither>();
+                        }
                         world.send_event::<GrassComputeEvent>(
                             GrassComputeError::FailedComputation(e, error).into(),
                         );
@@ -188,6 +191,9 @@ pub(crate) fn add_dither_task(
 fn on_dither_success(world: &mut World, e: Entity, buffer: DitheredBuffer) {
     let Some(mut dithered) = world.get_resource_mut::<Assets<DitheredBuffer>>() else {
         world.send_event::<GrassComputeEvent>(GrassComputeError::FailedRequestResource.into());
+        if let Some(mut entity_builder) = world.get_entity_mut(e) {
+            entity_builder.remove::<ComputeDither>();
+        }
         return;
     };
     let handle = dithered.add(buffer);

--- a/src/dithering.rs
+++ b/src/dithering.rs
@@ -68,7 +68,7 @@ pub(crate) fn dither_density_map(
 
     let mut dither_buffer = Vec::with_capacity(image_length as usize);
     if !matches!(dynamic_image, DynamicImage::ImageLuma8(_)) {
-        info!("The density map is prefered to be in Luma8(/R8) encoding");
+        info_once!("The density map is prefered to be in Luma8(/R8) encoding");
     }
     // This conversion doesn't cost anything if the image is already luma8 but makes up for most of the function duration otherwise.
     let buffer = dynamic_image.into_luma8();

--- a/src/render/assets/grass_shader.wgsl
+++ b/src/render/assets/grass_shader.wgsl
@@ -1,6 +1,5 @@
 #import bevy_pbr::mesh_functions::{mesh_position_local_to_clip, get_model_matrix}
 #import bevy_pbr::mesh_types::Mesh
-// #import bevy_pbr::mesh_view_bindings::globals
 #import bevy_pbr::mesh_bindings::mesh
 #import bevy_render::maths::affine_to_square
 

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -1,4 +1,7 @@
 use bevy::core_pipeline::core_3d::Opaque3d;
+use bevy::core_pipeline::prepass::{
+    DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass,
+};
 use bevy::pbr::{MeshPipelineKey, RenderMeshInstances};
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssets;
@@ -21,41 +24,60 @@ pub(crate) fn queue_grass_buffers(
     render_mesh_instances: Res<RenderMeshInstances>,
     meshes: Res<RenderAssets<Mesh>>,
     material_meshes: Query<(Entity, &WarblerHeight)>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<Opaque3d>)>,
+    mut views: Query<(
+        &ExtractedView,
+        &mut RenderPhase<Opaque3d>,
+        Has<DepthPrepass>,
+        Has<NormalPrepass>,
+        Has<MotionVectorPrepass>,
+        Has<DeferredPrepass>,
+    )>,
 ) {
-    let draw_custom = opaque_3d_draw_functions
-        .read()
-        .get_id::<GrassDrawCall>()
-        .unwrap();
+    let draw_custom = opaque_3d_draw_functions.read().id::<GrassDrawCall>();
     let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
 
-    for (view, mut opaque_phase) in &mut views {
-        let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
+    for (view, mut opaque_phase, depth_prepass, normal_prepass, motion_prepass, deferred_prepass) in
+        &mut views
+    {
+        let mut view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
+        if deferred_prepass {
+            view_key |= MeshPipelineKey::DEFERRED_PREPASS;
+        }
+        if depth_prepass {
+            view_key |= MeshPipelineKey::DEPTH_PREPASS;
+        }
+        if normal_prepass {
+            view_key |= MeshPipelineKey::NORMAL_PREPASS;
+        }
+        if motion_prepass {
+            view_key |= MeshPipelineKey::MOTION_VECTOR_PREPASS;
+        }
         for (entity, height) in material_meshes.iter() {
             let Some(mesh_instance) = render_mesh_instances.get(&entity) else {
                 continue;
             };
 
-            if let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) {
-                let mesh_key =
-                    view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                let mut grass_key = GrassRenderKey::from(mesh_key);
-                grass_key.uniform_height = match height {
-                    WarblerHeight::Uniform(_) => true,
-                    WarblerHeight::Texture(_) => false,
-                };
-                let pipeline = pipelines
-                    .specialize(&pipeline_cache, &grass_pipeline, grass_key, &mesh.layout)
-                    .unwrap();
-                opaque_phase.add(Opaque3d {
-                    entity,
-                    pipeline,
-                    draw_function: draw_custom,
-                    batch_range: 0..1,
-                    dynamic_offset: None,
-                    asset_id: mesh_instance.mesh_asset_id,
-                });
-            }
+            let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) else {
+                continue;
+            };
+            let mesh_key =
+                view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+            let mut grass_key = GrassRenderKey::from(mesh_key);
+            grass_key.uniform_height = match height {
+                WarblerHeight::Uniform(_) => true,
+                WarblerHeight::Texture(_) => false,
+            };
+            let pipeline = pipelines
+                .specialize(&pipeline_cache, &grass_pipeline, grass_key, &mesh.layout)
+                .unwrap();
+            opaque_phase.add(Opaque3d {
+                entity,
+                pipeline,
+                draw_function: draw_custom,
+                batch_range: 0..1,
+                dynamic_offset: None,
+                asset_id: mesh_instance.mesh_asset_id,
+            });
         }
     }
 }

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -21,7 +21,7 @@ use bevy::{
 };
 
 use crate::{
-    dithering::{add_dither_task, check_dither_compute_tasks, DitheredBuffer},
+    dithering::{add_dither_task, check_dither_compute_tasks, DitheredBuffer, GrassComputeEvent},
     map::{NormalMap, YMap},
     prelude::{GrassColor, WarblerHeight},
     render::{self, cache::UniformBuffer, extract, grass_pipeline::GrassPipeline, prepare, queue},
@@ -70,6 +70,7 @@ impl Plugin for WarblersPlugin {
         images.insert(DEFAULT_IMAGE_HANDLE, Image::default());
 
         app.add_systems(Update, (add_dither_task, check_dither_compute_tasks))
+            .add_event::<GrassComputeEvent>()
             .init_asset::<DitheredBuffer>()
             .add_plugins(RenderAssetPlugin::<DitheredBuffer>::default());
         // Init resources

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -21,7 +21,7 @@ use bevy::{
 };
 
 use crate::{
-    dithering::{add_dither_to_density, DitheredBuffer},
+    dithering::{add_dither_task, check_dither_compute_tasks, DitheredBuffer},
     map::{NormalMap, YMap},
     prelude::{GrassColor, WarblerHeight},
     render::{self, cache::UniformBuffer, extract, grass_pipeline::GrassPipeline, prepare, queue},
@@ -69,7 +69,7 @@ impl Plugin for WarblersPlugin {
         images.insert(DEFAULT_NORMAL_MAP_HANDLE, default_normal_map());
         images.insert(DEFAULT_IMAGE_HANDLE, Image::default());
 
-        app.add_systems(Update, add_dither_to_density)
+        app.add_systems(Update, (add_dither_task, check_dither_compute_tasks))
             .init_asset::<DitheredBuffer>()
             .add_plugins(RenderAssetPlugin::<DitheredBuffer>::default());
         // Init resources


### PR DESCRIPTION
Fixes #81
Fixes #86 
Dithering gets a speedup by slightly optimizing the code. 
The dithering of chunks now runs async. in the background instead of blocking the frame.
This is especially useful for any editor that uses the dithering code.
Also a event system was introduced to better track the dithering of certain chunks.
The new dithering code handles errors better and throws an error event instead of panicing. 
The most obvious error being that an entity gets deleted while the dithering runs in the background.